### PR TITLE
Inventory popup/dialog for recording spend & donation (#24)

### DIFF
--- a/app/inventory/page.tsx
+++ b/app/inventory/page.tsx
@@ -17,15 +17,16 @@ import { Button } from "@/components/ui/button"
 import { Checkbox } from "@/components/ui/checkbox"
 import { HugeiconsIcon } from "@hugeicons/react"
 import {
-  Search01Icon, ArrowDown01Icon, ArrowUp01Icon,
-ShoppingBasket01Icon, GiveBloodIcon, Delete01Icon, Edit01Icon
+  Search01Icon, ArrowUp01Icon, Delete01Icon, Edit01Icon,
 } from "@hugeicons/core-free-icons"
+import { toast } from "sonner"
 import { STORE_CATEGORIES } from "@/lib/treemap"
 import {
   loadPersistedGiftCards,
   upsertPersistedGiftCard,
   type PersistedGiftCard,
 } from "@/lib/inventory-persistence"
+import { GiftCardDialog } from "@/components/gift-card-dialog"
 import rawData from "./data.json"
 
 // ── Types ─────────────────────────────────────────────────────────────────────
@@ -64,21 +65,6 @@ function categoryForStore(store: string) {
   return STORE_CATEGORIES[store] ?? "Other"
 }
 
-function statusStyle(status: string) {
-  const normalized = status.toLowerCase()
-  if (normalized === "active") return "bg-[#bbf7d0] text-[#166534]"
-  if (normalized === "used" || normalized === "fully_redeemed") return "bg-[#f5f5f5] text-[#525252]"
-  if (normalized === "donated") return "bg-[#bfdbfe] text-[#1e40af]"
-  return "bg-[#fef9c3] text-[#854d0e]"
-}
-
-function fmt(iso: string) {
-  return new Date(iso).toLocaleString("en-US", {
-    month: "short", day: "numeric", year: "numeric",
-    hour: "numeric", minute: "2-digit", hour12: true,
-  })
-}
-
 // ── Page ──────────────────────────────────────────────────────────────────────
 
 export default function InventoryPage() {
@@ -96,22 +82,6 @@ export default function InventoryPage() {
   const [newNotes, setNewNotes] = React.useState("")
   const [addErr, setAddErr] = React.useState("")
   const [addSuccess, setAddSuccess] = React.useState("")
-
-  // Spend form
-  const [showSpend, setShowSpend] = React.useState(false)
-  const [spendAmt, setSpendAmt] = React.useState("")
-  const [spendVol, setSpendVol] = React.useState("")
-  const [spendNotes, setSpendNotes] = React.useState("")
-  const [spendErr, setSpendErr] = React.useState("")
-
-  // Donation form
-  const [showDonate, setShowDonate] = React.useState(false)
-  const [donateFull, setDonateFull] = React.useState(true)
-  const [donateAmt, setDonateAmt] = React.useState("")
-  const [donateRecip, setDonateRecip] = React.useState("")
-  const [donateVol, setDonateVol] = React.useState("")
-  const [donateNotes, setDonateNotes] = React.useState("")
-  const [donateErr, setDonateErr] = React.useState("")
 
   // Edit form
   const [showEditSheet, setShowEditSheet] = React.useState(false)
@@ -203,7 +173,6 @@ export default function InventoryPage() {
 
     upsertPersistedGiftCard(createdCard as PersistedGiftCard)
     setData(d => ({ ...d, cards: [createdCard, ...d.cards] }))
-    setSelectedId(createdCard.id)
     setNewStore("")
     setNewLast4("")
     setNewInitialAmount("")
@@ -211,65 +180,44 @@ export default function InventoryPage() {
     setAddSuccess("Gift card added successfully.")
   }
 
-  function selectCard(id: number) {
-    if (selectedId === id) {
-      setSelectedId(null)
-    } else {
-      setSelectedId(id)
-      setShowSpend(false); setShowDonate(false)
-      setSpendAmt(""); setSpendVol(""); setSpendNotes(""); setSpendErr("")
-      setDonateAmt(""); setDonateRecip(""); setDonateVol(""); setDonateNotes("")
-      setDonateErr(""); setDonateFull(true)
-    }
-  }
-
-  function handleSpend() {
-    setSpendErr("")
-    const amount = Number(Number(spendAmt).toFixed(2))
-    if (!spendAmt || isNaN(amount) || amount <= 0) { setSpendErr("Enter a valid amount."); return }
-    if (!spendVol) { setSpendErr("Please select a volunteer."); return }
-    if (amount > selectedCard!.remainingBalance) {
-      setSpendErr(`Exceeds remaining balance of $${selectedCard!.remainingBalance.toFixed(2)}.`); return
-    }
-    const newBal = selectedCard!.remainingBalance - amount
-    setData(d => ({
-      cards: d.cards.map(c => c.id === selectedId
-        ? { ...c, remainingBalance: newBal, status: newBal === 0 ? "Used" : c.status }
-        : c),
-      transactions: [...d.transactions, {
-        id: d.transactions.length + 1, cardId: selectedId!, date: new Date().toISOString(),
-        type: "spend", amount, volunteer: spendVol, recipient: null, notes: spendNotes,
-      }],
-    }))
-    setShowSpend(false); setSpendAmt(""); setSpendVol(""); setSpendNotes("")
-  }
-
-  function handleDonate() {
-    setDonateErr("")
-    if (!donateVol) { setDonateErr("Please select a volunteer."); return }
-    if (!donateRecip.trim()) { setDonateErr("Please enter a recipient name."); return }
-    let amount: number
-    if (donateFull) {
-      amount = selectedCard!.remainingBalance
-    } else {
-      amount = Number(Number(donateAmt).toFixed(2))
-      if (!donateAmt || isNaN(amount) || amount <= 0) { setDonateErr("Enter a valid amount."); return }
-      if (amount > selectedCard!.remainingBalance) {
-        setDonateErr(`Exceeds remaining balance of $${selectedCard!.remainingBalance.toFixed(2)}.`); return
+  // Record a spend on the currently-open card. Validation happens in the dialog.
+  function recordSpend(amount: number, volunteer: string, notes: string) {
+    if (selectedId == null) return
+    setData(d => {
+      const card = d.cards.find(c => c.id === selectedId)
+      if (!card) return d
+      const newBal = card.remainingBalance - amount
+      return {
+        cards: d.cards.map(c => c.id === selectedId
+          ? { ...c, remainingBalance: newBal, status: newBal === 0 ? "Used" : c.status }
+          : c),
+        transactions: [...d.transactions, {
+          id: d.transactions.length + 1, cardId: selectedId, date: new Date().toISOString(),
+          type: "spend", amount, volunteer, recipient: null, notes,
+        }],
       }
-    }
-    const newBal = selectedCard!.remainingBalance - amount
-    setData(d => ({
-      cards: d.cards.map(c => c.id === selectedId
-        ? { ...c, remainingBalance: newBal, status: newBal === 0 ? "Donated" : c.status }
-        : c),
-      transactions: [...d.transactions, {
-        id: d.transactions.length + 1, cardId: selectedId!, date: new Date().toISOString(),
-        type: "donation", amount, volunteer: donateVol, recipient: donateRecip, notes: donateNotes,
-      }],
-    }))
-    setShowDonate(false)
-    setDonateAmt(""); setDonateRecip(""); setDonateVol(""); setDonateNotes(""); setDonateFull(true)
+    })
+    toast.success(`Recorded a $${amount.toFixed(2)} spend.`)
+  }
+
+  // Record a donation-out on the currently-open card.
+  function recordDonation(amount: number, volunteer: string, recipient: string, notes: string) {
+    if (selectedId == null) return
+    setData(d => {
+      const card = d.cards.find(c => c.id === selectedId)
+      if (!card) return d
+      const newBal = card.remainingBalance - amount
+      return {
+        cards: d.cards.map(c => c.id === selectedId
+          ? { ...c, remainingBalance: newBal, status: newBal === 0 ? "Donated" : c.status }
+          : c),
+        transactions: [...d.transactions, {
+          id: d.transactions.length + 1, cardId: selectedId, date: new Date().toISOString(),
+          type: "donation", amount, volunteer, recipient, notes,
+        }],
+      }
+    })
+    toast.success(`Recorded a $${amount.toFixed(2)} donation to ${recipient}.`)
   }
 
   function deleteCard(id: number) {
@@ -277,29 +225,29 @@ export default function InventoryPage() {
       setData(d => ({
         cards: d.cards.filter(c => c.id !== id),
         transactions: d.transactions.filter(t => t.cardId !== id)
-      }));
-      if (selectedId === id) setSelectedId(null);
+      }))
+      if (selectedId === id) setSelectedId(null)
     }
   }
 
   function openEditCard(id: number) {
-    const card = data.cards.find(c => c.id === id);
+    const card = data.cards.find(c => c.id === id)
     if (card) {
-      setEditCardId(id);
-      setEditStore(card.store);
-      setEditInitialBalance(card.initialBalance.toString());
-      setEditRemainingBalance(card.remainingBalance.toString());
-      setShowEditSheet(true);
+      setEditCardId(id)
+      setEditStore(card.store)
+      setEditInitialBalance(card.initialBalance.toString())
+      setEditRemainingBalance(card.remainingBalance.toString())
+      setShowEditSheet(true)
     }
   }
 
   function saveEditCard() {
-    if (!editCardId) return;
-    const initial = parseFloat(editInitialBalance);
-    const remaining = parseFloat(editRemainingBalance);
+    if (!editCardId) return
+    const initial = parseFloat(editInitialBalance)
+    const remaining = parseFloat(editRemainingBalance)
     if (isNaN(initial) || isNaN(remaining) || initial < 0 || remaining < 0 || remaining > initial) {
-      alert("Invalid balances");
-      return;
+      alert("Invalid balances")
+      return
     }
     if (confirm("Are you sure you want to save these changes?")) {
       setData(d => ({
@@ -311,8 +259,8 @@ export default function InventoryPage() {
           remainingBalance: remaining,
           status: remaining === 0 ? "Used" : c.status
         } : c)
-      }));
-      setShowEditSheet(false);
+      }))
+      setShowEditSheet(false)
     }
   }
 
@@ -420,7 +368,7 @@ export default function InventoryPage() {
               <div className="px-6 py-4 border-b border-[#e2e8f0]">
                 <div className="flex items-center justify-between mb-3">
                   <div>
-                    <p className="text-sm font-semibold text-[#0a0a0a]">Gift Card Inventory</p>
+                    <p className="text-sm font-semibold text-[#0a0a0a]">Gift Cards Inventory</p>
                     <p className="text-xs text-[#737373] mt-0.5">Click a row to record a spend, donation, or view history</p>
                   </div>
                   <p className="text-xs text-[#737373]">{filteredCards.length} of {data.cards.length} cards</p>
@@ -448,7 +396,7 @@ export default function InventoryPage() {
                   <div className="relative">
                     <HugeiconsIcon icon={Search01Icon} strokeWidth={1.5} className="absolute left-2.5 top-1/2 -translate-y-1/2 size-3.5 text-[#a3a3a3] pointer-events-none" />
                     <Input
-                      placeholder="Search store or last 4"
+                      placeholder="Last 4 digits..."
                       value={searchQuery}
                       onChange={e => setSearchQuery(e.target.value)}
                       className="h-8 pl-8 text-sm rounded-[6px] w-52"
@@ -478,8 +426,6 @@ export default function InventoryPage() {
                       <TableHead className="text-xs font-medium text-[#737373] py-3">Card Number</TableHead>
                       <TableHead className="text-xs font-medium text-[#737373] py-3">Initial Balance</TableHead>
                       <TableHead className="text-xs font-medium text-[#737373] py-3">Remaining Balance</TableHead>
-                      <TableHead className="text-xs font-medium text-[#737373] py-3">Amount Spent</TableHead>
-                      <TableHead className="text-xs font-medium text-[#737373] py-3">Status</TableHead>
                       <TableHead className="text-xs font-medium text-[#737373] py-3">Added By</TableHead>
                       <TableHead className="text-xs font-medium text-[#737373] py-3 pr-6" />
                     </TableRow>
@@ -487,284 +433,64 @@ export default function InventoryPage() {
                   <TableBody>
                     {filteredCards.length === 0 ? (
                       <TableRow>
-                        <TableCell colSpan={9} className="h-24 text-center text-[#737373] text-sm">
+                        <TableCell colSpan={7} className="h-24 text-center text-[#737373] text-sm">
                           No cards match your search.
                         </TableCell>
                       </TableRow>
                     ) : filteredCards.map(card => {
-                      const isOpen = selectedId === card.id
                       const pct = card.initialBalance > 0
                         ? (card.remainingBalance / card.initialBalance) * 100
                         : 0
 
                       return (
-                        <React.Fragment key={card.id}>
-
-                          {/* Card row */}
-                          <TableRow
-                            className={`border-[#e2e8f0] cursor-pointer transition-colors ${isOpen ? "bg-[#f8faff]" : "hover:bg-[#fafafa]"}`}
-                            onClick={() => selectCard(card.id)}
-                          >
-                            <TableCell className="py-3 pl-6 align-middle" onClick={(e) => e.stopPropagation()}>
-                              <Checkbox
-                                checked={selectedRows.includes(card.id)}
-                                onCheckedChange={(checked) => {
-                                  if (checked) {
-                                    setSelectedRows(prev => [...prev, card.id])
-                                  } else {
-                                    setSelectedRows(prev => prev.filter(id => id !== card.id))
-                                  }
-                                }}
-                              />
-                            </TableCell>
-                            <TableCell className="text-sm font-medium text-[#0a0a0a] py-3">{card.store}</TableCell>
-                            <TableCell className="text-sm text-[#525252] py-3 font-mono tracking-wide align-middle">•••• {card.last4}</TableCell>
-                            <TableCell className="text-sm text-[#525252] py-3 align-middle">${card.initialBalance.toFixed(2)}</TableCell>
-                            <TableCell className="py-3 align-middle">
-                              <div className="flex flex-col gap-1">
-                                <span className={`text-sm font-medium ${card.remainingBalance === 0 ? "text-[#a3a3a3]" : "text-[#166534]"}`}>
-                                  ${card.remainingBalance.toFixed(2)}
-                                </span>
-                                <div className="w-20 h-1 bg-[#e2e8f0] rounded-full overflow-hidden">
-                                  <div className="h-full bg-[#22c55e] rounded-full" style={{ width: `${pct}%` }} />
-                                </div>
-                              </div>
-                            </TableCell>
-                            <TableCell className="text-sm text-[#C2410C] py-3 align-middle">${(card.initialBalance - card.remainingBalance).toFixed(2)}</TableCell>
-                            <TableCell className="py-3 align-middle">
-                              <span className={`text-xs font-semibold px-2.5 py-1 rounded-full ${statusStyle(card.status)}`}>
-                                {card.status}
+                        <TableRow
+                          key={card.id}
+                          className="border-[#e2e8f0] cursor-pointer transition-colors hover:bg-[#fafafa]"
+                          onClick={() => setSelectedId(card.id)}
+                        >
+                          <TableCell className="py-3 pl-6 align-middle" onClick={(e) => e.stopPropagation()}>
+                            <Checkbox
+                              checked={selectedRows.includes(card.id)}
+                              onCheckedChange={(checked) => {
+                                if (checked) {
+                                  setSelectedRows(prev => [...prev, card.id])
+                                } else {
+                                  setSelectedRows(prev => prev.filter(id => id !== card.id))
+                                }
+                              }}
+                            />
+                          </TableCell>
+                          <TableCell className="text-sm font-medium text-[#0a0a0a] py-3">{card.store}</TableCell>
+                          <TableCell className="text-sm text-[#525252] py-3 font-mono tracking-wide align-middle">•••• {card.last4}</TableCell>
+                          <TableCell className="text-sm text-[#525252] py-3 align-middle">${card.initialBalance.toFixed(2)}</TableCell>
+                          <TableCell className="py-3 align-middle">
+                            <div className="flex flex-col gap-1">
+                              <span className={`text-sm font-medium ${card.remainingBalance === 0 ? "text-[#a3a3a3]" : "text-[#166534]"}`}>
+                                ${card.remainingBalance.toFixed(2)}
                               </span>
-                            </TableCell>
-                            <TableCell className="text-sm text-[#525252] py-3 align-middle">{card.addedBy}</TableCell>
-                            <TableCell className="py-3 pr-6 align-middle text-right">
-                              <div className="flex items-center justify-end gap-2">
-                                <HugeiconsIcon
-                                  icon={Edit01Icon}
-                                  strokeWidth={2}
-                                  className="size-4 text-[#a3a3a3] hover:text-blue-500 cursor-pointer"
-                                  onClick={(e) => { e.stopPropagation(); openEditCard(card.id); }}
-                                />
-                                <HugeiconsIcon
-                                  icon={Delete01Icon}
-                                  strokeWidth={2}
-                                  className="size-4 text-[#a3a3a3] hover:text-red-500 cursor-pointer"
-                                  onClick={(e) => { e.stopPropagation(); deleteCard(card.id); }}
-                                />
-                                <HugeiconsIcon
-                                  icon={isOpen ? ArrowUp01Icon : ArrowDown01Icon}
-                                  strokeWidth={2}
-                                  className="size-4 text-[#a3a3a3] inline-block"
-                                />
+                              <div className="w-20 h-1 bg-[#e2e8f0] rounded-full overflow-hidden">
+                                <div className="h-full bg-[#22c55e] rounded-full" style={{ width: `${pct}%` }} />
                               </div>
-                            </TableCell>
-                          </TableRow>
-
-                          {/* Expanded detail panel */}
-                          {isOpen && selectedCard && (
-                            <TableRow className="bg-[#f8faff] hover:bg-[#f8faff] border-[#e2e8f0]">
-                              <TableCell colSpan={9} className="p-0">
-                                <div className="px-6 py-5 border-t border-[#dbeafe]">
-
-                                  {/* Action buttons — only if balance remains */}
-                                  {selectedCard.remainingBalance > 0 && (
-                                    <div className="flex gap-2 mb-4">
-                                      <button
-                                        onClick={() => { setShowSpend(v => !v); setShowDonate(false) }}
-                                        className={`flex items-center gap-1.5 text-sm font-medium px-3.5 py-2 rounded-[6px] border transition-colors ${showSpend ? "bg-[#0a0a0a] text-white border-[#0a0a0a]" : "bg-white text-[#0a0a0a] border-[#e2e8f0] hover:bg-[#fafafa]"}`}
-                                      >
-                                        <HugeiconsIcon icon={ShoppingBasket01Icon} strokeWidth={2} className="size-4" />
-                                        Record Spend
-                                      </button>
-                                      <button
-                                        onClick={() => { setShowDonate(v => !v); setShowSpend(false) }}
-                                        className={`flex items-center gap-1.5 text-sm font-medium px-3.5 py-2 rounded-[6px] border transition-colors ${showDonate ? "bg-[#0a0a0a] text-white border-[#0a0a0a]" : "bg-white text-[#0a0a0a] border-[#e2e8f0] hover:bg-[#fafafa]"}`}
-                                      >
-                                        <HugeiconsIcon icon={GiveBloodIcon} strokeWidth={2} className="size-4" />
-                                        Record Donation
-                                      </button>
-                                    </div>
-                                  )}
-
-                                  {/* Spend form */}
-                                  {showSpend && (
-                                    <div className="mb-5 bg-white border border-[#e2e8f0] rounded-[8px] p-4 space-y-3">
-                                      <p className="text-sm font-semibold text-[#0a0a0a]">Record a Spend</p>
-                                      <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
-                                        <div className="space-y-1.5">
-                                          <Label className="text-xs font-medium text-[#737373]">Amount ($)</Label>
-                                          <Input
-                                            type="number" min="0.01" step="0.01" placeholder="0.00"
-                                            value={spendAmt} onChange={e => setSpendAmt(e.target.value)}
-                                            className="h-8 text-sm rounded-[6px]"
-                                          />
-                                        </div>
-                                        <div className="space-y-1.5">
-                                          <Label className="text-xs font-medium text-[#737373]">Volunteer</Label>
-                                          <Select value={spendVol} onValueChange={(value) => setSpendVol(value ?? "")}>
-                                            <SelectTrigger size="sm" className="rounded-[6px]">
-                                              <SelectValue placeholder="Select volunteer" />
-                                            </SelectTrigger>
-                                            <SelectContent>
-                                              {VOLUNTEERS.map(v => <SelectItem key={v} value={v}>{v}</SelectItem>)}
-                                            </SelectContent>
-                                          </Select>
-                                        </div>
-                                        <div className="space-y-1.5">
-                                          <Label className="text-xs font-medium text-[#737373]">Notes (optional)</Label>
-                                          <Input
-                                            placeholder="e.g. Groceries for Family A"
-                                            value={spendNotes} onChange={e => setSpendNotes(e.target.value)}
-                                            className="h-8 text-sm rounded-[6px]"
-                                          />
-                                        </div>
-                                      </div>
-                                      {spendErr && <p className="text-xs text-red-500">{spendErr}</p>}
-                                      <div className="flex gap-2">
-                                        <button
-                                          onClick={handleSpend}
-                                          className="text-sm font-medium bg-[#0a0a0a] text-white px-3.5 py-1.5 rounded-[6px] hover:bg-[#262626] transition-colors"
-                                        >
-                                          Confirm Spend
-                                        </button>
-                                        <button
-                                          onClick={() => { setShowSpend(false); setSpendErr("") }}
-                                          className="text-sm font-medium text-[#737373] px-3.5 py-1.5 rounded-[6px] hover:bg-white transition-colors"
-                                        >
-                                          Cancel
-                                        </button>
-                                      </div>
-                                    </div>
-                                  )}
-
-                                  {/* Donation form */}
-                                  {showDonate && (
-                                    <div className="mb-5 bg-white border border-[#e2e8f0] rounded-[8px] p-4 space-y-3">
-                                      <p className="text-sm font-semibold text-[#0a0a0a]">Record a Donation Out</p>
-                                      <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
-                                        <div className="space-y-1.5">
-                                          <Label className="text-xs font-medium text-[#737373]">Recipient</Label>
-                                          <Input
-                                            placeholder="e.g. Family A"
-                                            value={donateRecip} onChange={e => setDonateRecip(e.target.value)}
-                                            className="h-8 text-sm rounded-[6px]"
-                                          />
-                                        </div>
-                                        <div className="space-y-1.5">
-                                          <Label className="text-xs font-medium text-[#737373]">Volunteer</Label>
-                                          <Select value={donateVol} onValueChange={(value) => setDonateVol(value ?? "")}>
-                                            <SelectTrigger size="sm" className="rounded-[6px]">
-                                              <SelectValue placeholder="Select volunteer" />
-                                            </SelectTrigger>
-                                            <SelectContent>
-                                              {VOLUNTEERS.map(v => <SelectItem key={v} value={v}>{v}</SelectItem>)}
-                                            </SelectContent>
-                                          </Select>
-                                        </div>
-                                        <div className="space-y-1.5">
-                                          <Label className="text-xs font-medium text-[#737373]">Amount</Label>
-                                          <div className="flex gap-3 items-center pt-0.5">
-                                            <label className="flex items-center gap-1.5 text-xs text-[#525252] cursor-pointer">
-                                              <input
-                                                type="radio" checked={donateFull}
-                                                onChange={() => { setDonateFull(true); setDonateAmt("") }}
-                                                className="accent-[#0a0a0a]"
-                                              />
-                                              Full (${selectedCard.remainingBalance.toFixed(2)})
-                                            </label>
-                                            <label className="flex items-center gap-1.5 text-xs text-[#525252] cursor-pointer">
-                                              <input
-                                                type="radio" checked={!donateFull}
-                                                onChange={() => setDonateFull(false)}
-                                                className="accent-[#0a0a0a]"
-                                              />
-                                              Partial
-                                            </label>
-                                          </div>
-                                          {!donateFull && (
-                                            <Input
-                                              type="number" min="0.01" step="0.01" placeholder="0.00"
-                                              value={donateAmt} onChange={e => setDonateAmt(e.target.value)}
-                                              className="h-8 text-sm rounded-[6px] mt-1.5"
-                                            />
-                                          )}
-                                        </div>
-                                      </div>
-                                      <div className="space-y-1.5">
-                                        <Label className="text-xs font-medium text-[#737373]">Notes (optional)</Label>
-                                        <Input
-                                          placeholder="e.g. Weekly groceries for the family"
-                                          value={donateNotes} onChange={e => setDonateNotes(e.target.value)}
-                                          className="h-8 text-sm rounded-[6px]"
-                                        />
-                                      </div>
-                                      {donateErr && <p className="text-xs text-red-500">{donateErr}</p>}
-                                      <div className="flex gap-2">
-                                        <button
-                                          onClick={handleDonate}
-                                          className="text-sm font-medium bg-[#0a0a0a] text-white px-3.5 py-1.5 rounded-[6px] hover:bg-[#262626] transition-colors"
-                                        >
-                                          Confirm Donation
-                                        </button>
-                                        <button
-                                          onClick={() => { setShowDonate(false); setDonateErr("") }}
-                                          className="text-sm font-medium text-[#737373] px-3.5 py-1.5 rounded-[6px] hover:bg-white transition-colors"
-                                        >
-                                          Cancel
-                                        </button>
-                                      </div>
-                                    </div>
-                                  )}
-
-                                  {/* Transaction history */}
-                                  <div>
-                                    <p className="text-xs font-semibold text-[#737373] uppercase tracking-wide mb-3">
-                                      Transaction History
-                                    </p>
-                                    {cardTxns.length === 0 ? (
-                                      <p className="text-sm text-[#a3a3a3] text-center py-4">
-                                        No transactions recorded for this card.
-                                      </p>
-                                    ) : (
-                                      <div className="bg-white border border-[#e2e8f0] rounded-[8px] overflow-hidden">
-                                        <table className="w-full text-sm">
-                                          <thead>
-                                            <tr className="bg-[#fafafa] border-b border-[#e2e8f0]">
-                                              <th className="text-xs font-medium text-[#737373] text-left py-2.5 pl-4 pr-3">Date & Time</th>
-                                              <th className="text-xs font-medium text-[#737373] text-left py-2.5 pr-3">Type</th>
-                                              <th className="text-xs font-medium text-[#737373] text-left py-2.5 pr-3">Amount</th>
-                                              <th className="text-xs font-medium text-[#737373] text-left py-2.5 pr-3">Volunteer</th>
-                                              <th className="text-xs font-medium text-[#737373] text-left py-2.5 pr-3">Recipient</th>
-                                              <th className="text-xs font-medium text-[#737373] text-left py-2.5 pr-4">Notes</th>
-                                            </tr>
-                                          </thead>
-                                          <tbody>
-                                            {cardTxns.map((t, i) => (
-                                              <tr key={t.id} className={i < cardTxns.length - 1 ? "border-b border-[#e2e8f0]" : ""}>
-                                                <td className="py-2.5 pl-4 pr-3 text-[#525252] whitespace-nowrap">{fmt(t.date)}</td>
-                                                <td className="py-2.5 pr-3">
-                                                  <span className={`text-xs font-semibold px-2 py-0.5 rounded-full ${t.type === "spend" ? "bg-[#fed7aa] text-[#9a3412]" : "bg-[#bbf7d0] text-[#166534]"}`}>
-                                                    {t.type === "spend" ? "Spend" : "Donation"}
-                                                  </span>
-                                                </td>
-                                                <td className="py-2.5 pr-3 font-medium text-[#0a0a0a]">-${t.amount.toFixed(2)}</td>
-                                                <td className="py-2.5 pr-3 text-[#525252]">{t.volunteer}</td>
-                                                <td className="py-2.5 pr-3 text-[#525252]">{t.recipient ?? "—"}</td>
-                                                <td className="py-2.5 pr-4 text-[#a3a3a3]">{t.notes || "—"}</td>
-                                              </tr>
-                                            ))}
-                                          </tbody>
-                                        </table>
-                                      </div>
-                                    )}
-                                  </div>
-
-                                </div>
-                              </TableCell>
-                            </TableRow>
-                          )}
-
-                        </React.Fragment>
+                            </div>
+                          </TableCell>
+                          <TableCell className="text-sm text-[#525252] py-3 align-middle">{card.addedBy}</TableCell>
+                          <TableCell className="py-3 pr-6 align-middle text-right" onClick={(e) => e.stopPropagation()}>
+                            <div className="flex items-center justify-end gap-2">
+                              <HugeiconsIcon
+                                icon={Edit01Icon}
+                                strokeWidth={2}
+                                className="size-4 text-[#a3a3a3] hover:text-blue-500 cursor-pointer"
+                                onClick={() => openEditCard(card.id)}
+                              />
+                              <HugeiconsIcon
+                                icon={Delete01Icon}
+                                strokeWidth={2}
+                                className="size-4 text-[#a3a3a3] hover:text-red-500 cursor-pointer"
+                                onClick={() => deleteCard(card.id)}
+                              />
+                            </div>
+                          </TableCell>
+                        </TableRow>
                       )
                     })}
                   </TableBody>
@@ -782,6 +508,17 @@ export default function InventoryPage() {
           </div>
         </div>
       </SidebarInset>
+
+      {/* ── Gift Card Dialog (spend / donation / history) ── */}
+      <GiftCardDialog
+        card={selectedCard}
+        transactions={cardTxns}
+        volunteers={VOLUNTEERS}
+        open={selectedId !== null}
+        onClose={() => setSelectedId(null)}
+        onSpend={recordSpend}
+        onDonate={recordDonation}
+      />
 
       {/* Edit Modal */}
       {showEditSheet && (

--- a/components/app-sidebar.tsx
+++ b/components/app-sidebar.tsx
@@ -69,7 +69,7 @@ const data = {
 
 export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
   return (
-    <Sidebar collapsible="offcanvas" {...props}>
+    <Sidebar collapsible="icon" {...props}>
       <SidebarHeader>
         <SidebarMenu>
           <SidebarMenuItem>

--- a/components/gift-card-dialog.tsx
+++ b/components/gift-card-dialog.tsx
@@ -1,0 +1,396 @@
+"use client"
+
+import * as React from "react"
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs"
+import {
+  Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
+} from "@/components/ui/select"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Textarea } from "@/components/ui/textarea"
+import { Button } from "@/components/ui/button"
+import { HugeiconsIcon } from "@hugeicons/react"
+import {
+  ShoppingBasket01Icon, GiveBloodIcon, ArrowUp01Icon,
+} from "@hugeicons/core-free-icons"
+import { cn } from "@/lib/utils"
+
+// ── Types (kept structurally identical to the page's GiftCard / Transaction) ──
+
+export type GiftCardDialogCard = {
+  id: number
+  store: string
+  last4: string
+  initialBalance: number
+  remainingBalance: number
+  status: string
+  addedBy: string
+}
+
+export type GiftCardDialogTxn = {
+  id: number
+  date: string
+  type: "spend" | "donation"
+  amount: number
+  volunteer: string
+  recipient: string | null
+  notes: string
+}
+
+type Props = {
+  card: GiftCardDialogCard | null
+  transactions: GiftCardDialogTxn[]
+  volunteers: string[]
+  open: boolean
+  onClose: () => void
+  onSpend: (amount: number, volunteer: string, notes: string) => void
+  onDonate: (amount: number, volunteer: string, recipient: string, notes: string) => void
+}
+
+// ── Store branding for the card visual ───────────────────────────────────────
+// Brand colors are intentionally literal (they are brand identities, not theme
+// tokens). Everything structural below uses semantic tokens.
+
+type Brand = { gradient: string; wordmark: string; spark?: boolean }
+
+function brandFor(store: string): Brand {
+  const key = store.toLowerCase()
+  if (key.includes("walmart")) return { gradient: "from-[#0071dc] to-[#004a99]", wordmark: "Walmart", spark: true }
+  if (key.includes("target")) return { gradient: "from-[#cc0000] to-[#8b0000]", wordmark: "Target" }
+  if (key.includes("amazon")) return { gradient: "from-[#232f3e] to-[#131a24]", wordmark: "amazon" }
+  if (key.includes("starbucks")) return { gradient: "from-[#00754a] to-[#00362a]", wordmark: "Starbucks" }
+  if (key.includes("kroger")) return { gradient: "from-[#004990] to-[#002a55]", wordmark: "Kroger" }
+  if (key.includes("costco")) return { gradient: "from-[#005daa] to-[#e31837]", wordmark: "Costco" }
+  if (key.includes("best buy")) return { gradient: "from-[#0046be] to-[#002a73]", wordmark: "Best Buy" }
+  if (key.includes("mcdonald")) return { gradient: "from-[#da291c] to-[#a01f15]", wordmark: "McDonald's" }
+  return { gradient: "from-slate-700 to-slate-900", wordmark: store }
+}
+
+function money(n: number) {
+  return `$${n.toLocaleString("en-US", { minimumFractionDigits: 0, maximumFractionDigits: 2 })}`
+}
+
+function fmt(iso: string) {
+  return new Date(iso).toLocaleString("en-US", {
+    month: "short", day: "numeric", year: "numeric",
+    hour: "numeric", minute: "2-digit", hour12: true,
+  })
+}
+
+// ── The store-branded gift card visual ───────────────────────────────────────
+
+function GiftCardVisual({ card }: { card: GiftCardDialogCard }) {
+  const brand = brandFor(card.store)
+  return (
+    <div
+      className={cn(
+        "relative h-44 w-full overflow-hidden rounded-2xl bg-gradient-to-br p-5 text-white shadow-sm",
+        brand.gradient
+      )}
+    >
+      {/* Walmart spark, otherwise nothing — wordmark carries the brand */}
+      {brand.spark && (
+        <svg
+          viewBox="0 0 100 100"
+          className="absolute left-4 top-4 size-16 text-[#ffc220]"
+          aria-hidden="true"
+        >
+          {Array.from({ length: 6 }).map((_, i) => (
+            <rect
+              key={i}
+              x="46" y="6" width="8" height="30" rx="4"
+              fill="currentColor"
+              transform={`rotate(${i * 60} 50 50)`}
+            />
+          ))}
+        </svg>
+      )}
+
+      <span className="absolute right-5 top-4 text-lg font-semibold tracking-tight">
+        {brand.wordmark}
+      </span>
+
+      <div className="absolute bottom-5 right-5 text-right">
+        <div className="leading-none">
+          <span className="text-3xl font-bold">{money(card.remainingBalance)}</span>
+          <span className="ml-1 text-base font-medium text-white/70">/ {money(card.initialBalance)}</span>
+        </div>
+        <div className="mt-2 font-mono text-sm tracking-widest text-white/80">
+          •••• {card.last4}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// ── Dialog ───────────────────────────────────────────────────────────────────
+
+export function GiftCardDialog({
+  card, transactions, volunteers, open, onClose, onSpend, onDonate,
+}: Props) {
+  const panelRef = React.useRef<HTMLDivElement>(null)
+  const prevFocus = React.useRef<HTMLElement | null>(null)
+
+  const canRecord = !!card && card.remainingBalance > 0
+  const [tab, setTab] = React.useState<string>("spend")
+
+  // form state (shared across spend/donate; recipient only used for donate)
+  const [amount, setAmount] = React.useState("")
+  const [volunteer, setVolunteer] = React.useState("")
+  const [recipient, setRecipient] = React.useState("")
+  const [notes, setNotes] = React.useState("")
+  const [error, setError] = React.useState("")
+
+  const resetForm = React.useCallback(() => {
+    setAmount(""); setVolunteer(""); setRecipient(""); setNotes(""); setError("")
+  }, [])
+
+  // Reset whenever a different card is opened.
+  React.useEffect(() => {
+    if (!open || !card) return
+    resetForm()
+    setTab(card.remainingBalance > 0 ? "spend" : "history")
+  }, [open, card?.id, resetForm]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Clear errors when switching tabs.
+  React.useEffect(() => { setError("") }, [tab])
+
+  // Esc to close + body scroll lock + focus management.
+  React.useEffect(() => {
+    if (!open) return
+    prevFocus.current = document.activeElement as HTMLElement
+    const { overflow } = document.body.style
+    document.body.style.overflow = "hidden"
+    panelRef.current?.focus()
+
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose()
+    }
+    document.addEventListener("keydown", onKey)
+    return () => {
+      document.removeEventListener("keydown", onKey)
+      document.body.style.overflow = overflow
+      prevFocus.current?.focus?.()
+    }
+  }, [open, onClose])
+
+  if (!open || !card) return null
+
+  function validAmount(): number | null {
+    const value = Number(Number(amount).toFixed(2))
+    if (!amount || isNaN(value) || value <= 0) { setError("Enter an amount greater than $0."); return null }
+    if (value > card!.remainingBalance) {
+      setError(`That's more than the ${money(card!.remainingBalance)} left on this card.`); return null
+    }
+    return value
+  }
+
+  function confirmSpend() {
+    setError("")
+    const value = validAmount()
+    if (value === null) return
+    if (!volunteer) { setError("Choose a volunteer."); return }
+    onSpend(value, volunteer, notes.trim())
+    resetForm()
+    setTab("history")
+  }
+
+  function confirmDonate() {
+    setError("")
+    const value = validAmount()
+    if (value === null) return
+    if (!volunteer) { setError("Choose a volunteer."); return }
+    if (!recipient.trim()) { setError("Enter a recipient."); return }
+    onDonate(value, volunteer, recipient.trim(), notes.trim())
+    resetForm()
+    setTab("history")
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+      onMouseDown={(e) => { if (e.target === e.currentTarget) onClose() }}
+    >
+      <div
+        ref={panelRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="gift-card-dialog-title"
+        tabIndex={-1}
+        className="flex max-h-[90vh] w-full max-w-lg flex-col overflow-hidden rounded-2xl bg-background shadow-xl outline-none"
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-6 pt-5">
+          <h2 id="gift-card-dialog-title" className="text-base font-semibold text-foreground">
+            Gift Card Details
+          </h2>
+          <button
+            onClick={onClose}
+            aria-label="Close"
+            className="rounded-md p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+          >
+            <HugeiconsIcon icon={ArrowUp01Icon} strokeWidth={2} className="size-5 rotate-45" />
+          </button>
+        </div>
+
+        {/* Scrollable body */}
+        <div className="flex-1 overflow-y-auto px-6 pb-2 pt-4">
+          <GiftCardVisual card={card} />
+
+          <Tabs value={tab} onValueChange={(v) => setTab(v as string)} className="mt-5">
+            <TabsList className="w-full">
+              <TabsTrigger value="spend" disabled={!canRecord} className="flex-1">
+                <HugeiconsIcon icon={ShoppingBasket01Icon} strokeWidth={2} />
+                Record Spending
+              </TabsTrigger>
+              <TabsTrigger value="donation" disabled={!canRecord} className="flex-1">
+                <HugeiconsIcon icon={GiveBloodIcon} strokeWidth={2} />
+                Record Donation
+              </TabsTrigger>
+              <TabsTrigger value="history" className="flex-1">
+                Transaction History
+              </TabsTrigger>
+            </TabsList>
+
+            {/* Record Spending — amount, volunteer, notes (no recipient) */}
+            <TabsContent value="spend" className="pt-4">
+              <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                <Field label="Amount">
+                  <Input
+                    type="number" min="0.01" step="0.01" placeholder="e.g. $30"
+                    value={amount} onChange={(e) => setAmount(e.target.value)}
+                  />
+                </Field>
+                <Field label="Volunteer">
+                  <VolunteerSelect value={volunteer} onChange={setVolunteer} volunteers={volunteers} />
+                </Field>
+              </div>
+              <Field label="Notes" className="mt-3">
+                <Textarea
+                  placeholder="e.g. Weekly groceries for the family"
+                  value={notes} onChange={(e) => setNotes(e.target.value)}
+                  className="min-h-16"
+                />
+              </Field>
+              {error && <p className="mt-3 text-sm text-red-600">{error}</p>}
+            </TabsContent>
+
+            {/* Record Donation — amount, volunteer, recipient, notes */}
+            <TabsContent value="donation" className="pt-4">
+              <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                <Field label="Amount">
+                  <Input
+                    type="number" min="0.01" step="0.01" placeholder="e.g. $30"
+                    value={amount} onChange={(e) => setAmount(e.target.value)}
+                  />
+                </Field>
+                <Field label="Volunteer">
+                  <VolunteerSelect value={volunteer} onChange={setVolunteer} volunteers={volunteers} />
+                </Field>
+              </div>
+              <Field label="Recipient" className="mt-3">
+                <Input
+                  placeholder="e.g. Family A"
+                  value={recipient} onChange={(e) => setRecipient(e.target.value)}
+                />
+              </Field>
+              <Field label="Notes" className="mt-3">
+                <Textarea
+                  placeholder="e.g. Weekly groceries for the family"
+                  value={notes} onChange={(e) => setNotes(e.target.value)}
+                  className="min-h-16"
+                />
+              </Field>
+              {error && <p className="mt-3 text-sm text-red-600">{error}</p>}
+            </TabsContent>
+
+            {/* Transaction History — read-only */}
+            <TabsContent value="history" className="pt-4">
+              {transactions.length === 0 ? (
+                <p className="py-8 text-center text-sm text-muted-foreground">
+                  No transactions yet. Record a spend or donation to start the history.
+                </p>
+              ) : (
+                <div className="overflow-x-auto rounded-lg border">
+                  <table className="w-full text-sm">
+                    <thead>
+                      <tr className="border-b bg-muted/50 text-left">
+                        <th className="px-3 py-2 text-xs font-medium text-muted-foreground">Date &amp; Time</th>
+                        <th className="px-3 py-2 text-xs font-medium text-muted-foreground">Type</th>
+                        <th className="px-3 py-2 text-xs font-medium text-muted-foreground">Amount</th>
+                        <th className="px-3 py-2 text-xs font-medium text-muted-foreground">Volunteer</th>
+                        <th className="px-3 py-2 text-xs font-medium text-muted-foreground">Recipient</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {transactions.map((t, i) => (
+                        <tr key={t.id} className={i < transactions.length - 1 ? "border-b" : ""}>
+                          <td className="whitespace-nowrap px-3 py-2.5 text-muted-foreground">{fmt(t.date)}</td>
+                          <td className="px-3 py-2.5">
+                            <span
+                              className={cn(
+                                "rounded-full px-2 py-0.5 text-xs font-semibold",
+                                t.type === "spend"
+                                  ? "bg-amber-100 text-amber-700"
+                                  : "bg-blue-100 text-blue-700"
+                              )}
+                            >
+                              {t.type === "spend" ? "Spent" : "Donated"}
+                            </span>
+                          </td>
+                          <td className="px-3 py-2.5 font-medium text-red-600">-{money(t.amount)}</td>
+                          <td className="px-3 py-2.5 text-muted-foreground">{t.volunteer}</td>
+                          <td className="px-3 py-2.5 text-muted-foreground">{t.recipient ?? "—"}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+            </TabsContent>
+          </Tabs>
+        </div>
+
+        {/* Footer — Cancel + Confirm (hidden on the read-only history tab) */}
+        {tab !== "history" && (
+          <div className="flex items-center justify-end gap-2 border-t px-6 py-4">
+            <Button variant="ghost" onClick={onClose}>Cancel</Button>
+            {tab === "spend" ? (
+              <Button onClick={confirmSpend}>Confirm Spend</Button>
+            ) : (
+              <Button onClick={confirmDonate}>Confirm Donation</Button>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+// ── Small local helpers ──────────────────────────────────────────────────────
+
+function Field({
+  label, children, className,
+}: { label: string; children: React.ReactNode; className?: string }) {
+  return (
+    <div className={cn("space-y-1.5", className)}>
+      <Label className="text-xs font-medium text-muted-foreground">{label}</Label>
+      {children}
+    </div>
+  )
+}
+
+function VolunteerSelect({
+  value, onChange, volunteers,
+}: { value: string; onChange: (v: string) => void; volunteers: string[] }) {
+  return (
+    <Select value={value} onValueChange={(v) => onChange(v ?? "")}>
+      <SelectTrigger size="sm" className="w-full">
+        <SelectValue placeholder="Select Volunteer" />
+      </SelectTrigger>
+      <SelectContent>
+        {volunteers.map((v) => <SelectItem key={v} value={v}>{v}</SelectItem>)}
+      </SelectContent>
+    </Select>
+  )
+}

--- a/components/nav-main.tsx
+++ b/components/nav-main.tsx
@@ -33,6 +33,7 @@ export function NavMain({
                   isActive={isActive}
                   render={<Link href={item.url} />}
                   className="flex items-center gap-2"
+                  tooltip={item.title}
                 >
                   {item.icon}
                   <span>{item.title}</span>

--- a/components/nav-secondary.tsx
+++ b/components/nav-secondary.tsx
@@ -36,6 +36,7 @@ export function NavSecondary({
                   isActive={isActive}
                   render={<Link href={item.url} />}
                   className="flex items-center gap-2"
+                  tooltip={item.title}
                 >
                   {item.icon}
                   <span>{item.title}</span>


### PR DESCRIPTION
Closes #24
Moves the inventory spend/donation flow from an inline expanded row into a centered popup dialog, per the Figma.
What's included:

New GiftCardDialog component: store-branded gift-card visual, three tabs (Record Spending / Record Donation / Transaction History), form fields,  Cancel/Confirm actions.
Inventory table updated to match the Figma columns; clicking a row now opens the dialog.
Field validation
Real-time balance + transaction-history updates on confirm.
-Responsive

-Tested locally
Opening as a draft for review.